### PR TITLE
Add Camb AI narration, transcription, and one-shot dubbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "postinstall:electron": "electron-builder install-app-deps"
   },
   "dependencies": {
+    "@camb-ai/sdk": "^1.0.0",
     "@emotion/styled": "^11.14.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@google/genai": "^0.9.0",

--- a/parakeet_wrapper/app.py
+++ b/parakeet_wrapper/app.py
@@ -57,6 +57,15 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# Camb AI STT adapter (mounted alongside Parakeet's native endpoints).
+# Routes: /camb/, /camb/transcribe, /camb/transcribe_base64
+try:
+    from camb_stt import camb_router  # type: ignore
+    app.include_router(camb_router)
+    logger.info("Mounted Camb AI STT router at /camb")
+except Exception as _camb_import_err:
+    logger.warning(f"Camb STT router not mounted: {_camb_import_err}")
+
 # --- CORS ---
 app.add_middleware(
     CORSMiddleware,

--- a/parakeet_wrapper/camb_stt.py
+++ b/parakeet_wrapper/camb_stt.py
@@ -1,0 +1,187 @@
+"""Camb AI STT adapter — drop-in alternative to Parakeet's transcribe endpoints.
+
+Mounted into the Parakeet FastAPI app via ``app.include_router(camb_router)``.
+
+Uses the real camb-sdk Python shape:
+- Import: ``from camb.client import CambAI`` (the top-level ``from camb import CambAI``
+  crashes on Python 3.14 due to a broken lazy-import map in the SDK).
+- Languages are NUMERIC ids. Resolve short codes via ``client.languages.get_source_languages``.
+- ``create_transcription`` → ``task_id`` (dict) → poll ``get_transcription_task_status``
+  until ``status == 'SUCCESS'`` → ``get_transcription_result(run_id=...)`` → ``.transcript``
+  (list of ``{start, end, text, speaker}``).
+
+Auth: ``CAMB_API_KEY`` env var.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import tempfile
+import time
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+try:
+    from camb.client import CambAI  # type: ignore
+    HAS_CAMB = True
+except Exception:  # pragma: no cover
+    CambAI = None  # type: ignore
+    HAS_CAMB = False
+    logger.warning("camb-sdk not installed — Camb STT adapter will return 503")
+
+camb_router = APIRouter(prefix="/camb", tags=["camb-stt"])
+
+
+def _client():
+    if not HAS_CAMB:
+        raise HTTPException(status_code=503, detail="camb-sdk not installed")
+    api_key = os.environ.get("CAMB_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=503, detail="CAMB_API_KEY not set")
+    return CambAI(api_key=api_key)
+
+
+def _get(obj, key, default=None):
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _resolve_lang_id(client, code: str) -> int:
+    if not code:
+        return 1
+    low = code.strip().lower()
+    base = low.split("-")[0].split("_")[0]
+    langs = client.languages.get_source_languages()
+    def sn(l): return (_get(l, "short_name") or "").lower()
+    for l in langs:
+        if sn(l) == low:
+            return _get(l, "id")
+    for l in langs:
+        if sn(l).startswith(base):
+            return _get(l, "id")
+    return 1  # fall back to en-us
+
+
+def _poll(status_fn, task_id: str, interval: float = 3.0, timeout: float = 900.0):
+    start = time.time()
+    while time.time() - start < timeout:
+        res = status_fn(task_id=task_id)
+        st = _get(res, "status")
+        if st == "SUCCESS":
+            return _get(res, "run_id")
+        if st in ("ERROR", "FAILURE", "REVOKED"):
+            reason = _get(res, "exception_reason") or _get(res, "message") or st
+            raise RuntimeError(f"Camb task {task_id} failed: {reason}")
+        time.sleep(interval)
+    raise TimeoutError(f"Camb task {task_id} timed out after {timeout}s")
+
+
+def _fmt_ts(t: float) -> str:
+    if t < 0:
+        t = 0.0
+    h = int(t // 3600)
+    m = int((t % 3600) // 60)
+    s = int(t % 60)
+    ms = int(round((t - int(t)) * 1000))
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _transcribe_path(audio_path: str, language: str = "en") -> dict:
+    """Shared helper — runs the full Camb transcription flow against a file path."""
+    client = _client()
+    lang_id = _resolve_lang_id(client, language)
+    with open(audio_path, "rb") as fh:
+        created = client.transcription.create_transcription(
+            media_file=fh, language=lang_id
+        )
+    task_id = _get(created, "task_id")
+    if not task_id:
+        raise RuntimeError(f"Camb create_transcription returned no task_id: {created!r}")
+    run_id = _poll(client.transcription.get_transcription_task_status, task_id)
+    result = client.transcription.get_transcription_result(run_id=run_id)
+    segs = _get(result, "transcript") or _get(result, "segments") or []
+    normalized = []
+    text_parts = []
+    srt_lines = []
+    for i, s in enumerate(segs, start=1):
+        start_t = float(_get(s, "start", 0.0) or 0.0)
+        end_t = float(_get(s, "end", start_t) or start_t)
+        seg_text = (_get(s, "text") or "").strip()
+        speaker = _get(s, "speaker") or ""
+        normalized.append({
+            "start": start_t, "end": end_t, "text": seg_text, "speaker": speaker,
+        })
+        text_parts.append(seg_text)
+        srt_lines.append(f"{i}\n{_fmt_ts(start_t)} --> {_fmt_ts(end_t)}\n{seg_text}\n")
+    return {
+        "text": " ".join(p for p in text_parts if p),
+        "srt": "\n".join(srt_lines),
+        "segments": normalized,
+        "language": language,
+    }
+
+
+class Base64Payload(BaseModel):
+    audio_base64: str
+    filename: Optional[str] = "segment.wav"
+    language: Optional[str] = "en"
+    # Present for Parakeet shape-compat; Camb segments internally.
+    segment_strategy: Optional[str] = "sentence"
+    max_chars: Optional[int] = 60
+    max_words: Optional[int] = 7
+    pause_threshold: Optional[float] = 0.8
+
+
+@camb_router.get("/health")
+def camb_health():
+    return {
+        "available": HAS_CAMB and bool(os.environ.get("CAMB_API_KEY")),
+        "sdk_installed": HAS_CAMB,
+        "api_key_set": bool(os.environ.get("CAMB_API_KEY")),
+    }
+
+
+@camb_router.post("/transcribe_base64")
+def camb_transcribe_base64(payload: Base64Payload):
+    suffix = os.path.splitext(payload.filename or "segment.wav")[1] or ".wav"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(base64.b64decode(payload.audio_base64))
+        tmp_path = tmp.name
+    try:
+        return _transcribe_path(tmp_path, payload.language or "en")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Camb transcribe_base64 failed")
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+@camb_router.post("/transcribe")
+async def camb_transcribe(file: UploadFile = File(...), language: str = Form("en")):
+    suffix = os.path.splitext(file.filename or "segment.wav")[1] or ".wav"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(await file.read())
+        tmp_path = tmp.name
+    try:
+        return _transcribe_path(tmp_path, language)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Camb transcribe failed")
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass

--- a/parakeet_wrapper/requirements.txt
+++ b/parakeet_wrapper/requirements.txt
@@ -7,3 +7,4 @@ scipy
 # onnxruntime-directml is Windows-only, use onnxruntime instead on Linux
 # onnxruntime-directml ; sys_platform == "win32"
 onnxruntime ; sys_platform != "win32"
+camb-sdk

--- a/server/controllers/cambController.js
+++ b/server/controllers/cambController.js
@@ -1,0 +1,241 @@
+/**
+ * Camb AI controller for oneclick-subtitles-generator (Node/Express side).
+ *
+ * Uses the real @camb-ai/sdk shape:
+ *   - Export is `CambClient`, not `CambAI`.
+ *   - Languages are numeric ids — resolve via `client.languages.getSourceLanguages()`
+ *     / `getTargetLanguages()` and `startsWith` match on `short_name`.
+ *   - Transcription, TTS, and dubbing are task-based: create → poll status → fetch result.
+ *   - The streaming `tts-stream` endpoint REQUIRES `voice_id` and (for mars-flash)
+ *     an `output_configuration: { format: 'wav', sample_rate: 22050 }` to get real WAV.
+ *
+ * Auth: CAMB_API_KEY env var.
+ */
+'use strict';
+
+const fs = require('fs');
+
+let CambClient = null;
+try {
+  ({ CambClient } = require('@camb-ai/sdk'));
+} catch (_) {
+  CambClient = null;
+}
+
+let _client = null;
+function getClient() {
+  if (!CambClient) throw Object.assign(new Error('@camb-ai/sdk not installed'), { statusCode: 503 });
+  const apiKey = process.env.CAMB_API_KEY;
+  if (!apiKey) throw Object.assign(new Error('CAMB_API_KEY not set'), { statusCode: 503 });
+  if (!_client) _client = new CambClient({ apiKey });
+  return _client;
+}
+
+let _srcLangs = null;
+let _tgtLangs = null;
+
+function _findLangId(list, code) {
+  if (!code || !Array.isArray(list)) return null;
+  const low = String(code).toLowerCase();
+  const base = low.split(/[-_]/)[0];
+  const sn = (l) => (l.short_name || '').toLowerCase();
+  return (
+    list.find((l) => sn(l) === low)?.id ??
+    list.find((l) => sn(l).startsWith(base))?.id ??
+    list.find((l) => (l.language || '').toLowerCase().startsWith(base))?.id ??
+    null
+  );
+}
+
+async function resolveSourceLang(code) {
+  const c = getClient();
+  if (!_srcLangs) _srcLangs = await c.languages.getSourceLanguages();
+  return _findLangId(_srcLangs, code);
+}
+
+async function resolveTargetLang(code) {
+  const c = getClient();
+  if (!_tgtLangs) _tgtLangs = await c.languages.getTargetLanguages();
+  return _findLangId(_tgtLangs, code);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function pollTask(statusFn, taskId, { intervalMs = 2000, timeoutMs = 900000 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const res = await statusFn({ task_id: taskId });
+    const status = res?.status;
+    if (status === 'SUCCESS') return res.run_id;
+    if (status === 'ERROR' || status === 'FAILURE') {
+      throw new Error(`Camb task ${taskId} failed: ${JSON.stringify(res?.exception_reason || res?.message || status)}`);
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Camb task ${taskId} timed out after ${timeoutMs}ms`);
+}
+
+function fmtTs(sec) {
+  const ms = Math.max(0, Math.round(Number(sec) * 1000));
+  const hh = String(Math.floor(ms / 3600000)).padStart(2, '0');
+  const mm = String(Math.floor((ms % 3600000) / 60000)).padStart(2, '0');
+  const ss = String(Math.floor((ms % 60000) / 1000)).padStart(2, '0');
+  const mmm = String(ms % 1000).padStart(3, '0');
+  return `${hh}:${mm}:${ss},${mmm}`;
+}
+function transcriptToSrt(segments) {
+  return segments
+    .map((s, i) => `${i + 1}\n${fmtTs(s.start)} --> ${fmtTs(s.end)}\n${(s.text || '').trim()}\n`)
+    .join('\n');
+}
+
+async function transcribeFile(audioPath, language = 'en') {
+  const client = getClient();
+  const langId = (await resolveSourceLang(language)) ?? 1;
+  const stream = fs.createReadStream(audioPath);
+  const created = await client.transcription.createTranscription({ media_file: stream, language: langId });
+  const taskId = created?.task_id;
+  if (!taskId) throw new Error('Camb createTranscription returned no task_id');
+  const runId = await pollTask(
+    (req) => client.transcription.getTranscriptionTaskStatus(req),
+    taskId,
+    { intervalMs: 3000 },
+  );
+  const result = await client.transcription.getTranscriptionResult({ run_id: runId });
+  const segs = (result?.transcript || []).map((s) => ({
+    start: Number(s.start) || 0,
+    end: Number(s.end) || 0,
+    text: s.text || '',
+    speaker: s.speaker || '',
+  }));
+  return {
+    text: segs.map((s) => s.text).filter(Boolean).join(' '),
+    srt: transcriptToSrt(segs),
+    segments: segs,
+    language,
+  };
+}
+
+const DEFAULT_VOICE_ID = Number(process.env.CAMB_DEFAULT_VOICE_ID) || 156549;
+
+async function ttsStream({
+  text,
+  language = 'en-us',
+  speechModel = 'mars-flash',
+  voiceId = DEFAULT_VOICE_ID,
+} = {}) {
+  if (!text || !text.trim()) throw new Error('text is required');
+  const apiKey = process.env.CAMB_API_KEY;
+  if (!apiKey) throw Object.assign(new Error('CAMB_API_KEY not set'), { statusCode: 503 });
+  const body = {
+    text,
+    language,
+    speech_model: speechModel,
+    voice_id: voiceId,
+    output_configuration: { format: 'wav', sample_rate: 22050 },
+  };
+  const res = await fetch('https://client.camb.ai/apis/tts-stream', {
+    method: 'POST',
+    headers: { 'x-api-key': apiKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    const err = new Error(`Camb tts-stream ${res.status}: ${detail}`);
+    err.statusCode = res.status;
+    throw err;
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+async function dubVideoUrl({ videoUrl, sourceLanguage = 'en', targetLanguage = 'zh' } = {}) {
+  if (!videoUrl || !/^https?:\/\//.test(videoUrl)) {
+    throw new Error('Camb dubbing requires a public http(s) video_url');
+  }
+  const client = getClient();
+  const srcId = (await resolveSourceLang(sourceLanguage)) ?? 1;
+  const tgtId = (await resolveTargetLang(targetLanguage)) ?? 139;
+  const created = await client.dub.endToEndDubbing({
+    video_url: videoUrl, source_language: srcId, target_language: tgtId,
+  });
+  const taskId = created?.task_id;
+  if (!taskId) throw new Error('Camb endToEndDubbing returned no task_id');
+  const runId = await pollTask(
+    (req) => client.dub.getEndToEndDubbingStatus(req),
+    taskId,
+    { intervalMs: 5000, timeoutMs: 1800000 },
+  );
+  const info = await client.dub.getDubbedRunInfo({ run_id: runId });
+  return { runId, info };
+}
+
+const getStatus = async (_req, res) => {
+  res.json({
+    available: !!CambClient && !!process.env.CAMB_API_KEY,
+    sdk_installed: !!CambClient,
+    api_key_set: !!process.env.CAMB_API_KEY,
+  });
+};
+
+const transcribe = async (req, res) => {
+  try {
+    const audioPath = req.body?.audioPath || req.file?.path;
+    if (!audioPath) return res.status(400).json({ error: 'audioPath or uploaded file required' });
+    const language = req.body?.language || 'en';
+    res.json(await transcribeFile(audioPath, language));
+  } catch (e) {
+    res.status(e.statusCode || 500).json({ error: e.message });
+  }
+};
+
+const generateNarration = async (req, res) => {
+  try {
+    const { text, language, voice_id: voiceId, speech_model: speechModel } = req.body || {};
+    const wav = await ttsStream({ text, language, speechModel, voiceId });
+    res.setHeader('Content-Type', 'audio/wav');
+    res.setHeader('Content-Length', wav.length);
+    res.send(wav);
+  } catch (e) {
+    res.status(e.statusCode || 500).json({ error: e.message });
+  }
+};
+
+const dub = async (req, res) => {
+  try {
+    const { video_url: videoUrl, source_language, target_language } = req.body || {};
+    res.json(await dubVideoUrl({
+      videoUrl, sourceLanguage: source_language, targetLanguage: target_language,
+    }));
+  } catch (e) {
+    res.status(e.statusCode || 500).json({ error: e.message });
+  }
+};
+
+const getVoices = async (req, res) => {
+  try {
+    const apiKey = process.env.CAMB_API_KEY;
+    if (!apiKey) return res.status(503).json({ error: 'CAMB_API_KEY not set' });
+    const r = await fetch('https://client.camb.ai/apis/list-voices', { headers: { 'x-api-key': apiKey } });
+    if (!r.ok) return res.status(r.status).send(await r.text());
+    const body = await r.json();
+    const language = req.query?.language;
+    const filtered = language
+      ? body.filter((v) => String(v.language || '').toLowerCase().includes(String(language).toLowerCase()))
+      : body;
+    res.json({ count: filtered.length, voices: filtered.slice(0, 200) });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+};
+
+module.exports = {
+  getStatus,
+  getVoices,
+  generateNarration,
+  transcribe,
+  dub,
+  // test-friendly named exports
+  transcribeFile,
+  ttsStream,
+  dubVideoUrl,
+};

--- a/server/narration_service/narration_blueprint.py
+++ b/server/narration_service/narration_blueprint.py
@@ -6,6 +6,7 @@ from .narration_models import models_bp
 from .narration_audio import audio_bp
 from .narration_generation import generation_bp
 from .narration_edge_gtts import edge_gtts_bp
+from .narration_camb import camb_bp
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,7 @@ narration_bp.register_blueprint(models_bp, url_prefix='')
 narration_bp.register_blueprint(audio_bp, url_prefix='')
 narration_bp.register_blueprint(generation_bp, url_prefix='')
 narration_bp.register_blueprint(edge_gtts_bp, url_prefix='')
+narration_bp.register_blueprint(camb_bp, url_prefix='')
 
 # Add routes for serving audio files
 @narration_bp.route('/audio/<path:filename>', methods=['GET'])

--- a/server/narration_service/narration_camb.py
+++ b/server/narration_service/narration_camb.py
@@ -1,0 +1,269 @@
+"""Camb AI narration blueprint (Flask).
+
+Provides TTS, transcription, and dubbing endpoints that mirror the shape of
+the existing Edge TTS / gTTS blueprint so the frontend can stream SSE the
+same way.
+
+Uses the REAL camb-sdk Python shape (see integrations/CAMB_API_NOTES.md):
+- ``from camb.client import CambAI`` (NOT ``from camb import CambAI`` — broken on Py 3.14)
+- Languages are NUMERIC ids from ``client.languages.get_source_languages()``
+- Transcription / translation / dubbing / task-based TTS all follow:
+  create → poll ``get_*_task_status`` → fetch ``get_*_result(run_id=...)``
+- Streaming TTS (preferred, low-latency): ``client.text_to_speech.tts(...)``
+  returns ``Iterator[bytes]`` of WAV chunks. Requires ``voice_id`` and an
+  ``output_configuration`` with ``format='wav'`` to get real WAV.
+
+Auth: ``CAMB_API_KEY`` env var.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import Optional
+
+from flask import Blueprint, Response, jsonify, request
+
+try:
+    from .narration_config import OUTPUT_AUDIO_DIR  # type: ignore
+    from .directory_utils import ensure_subtitle_directory, get_next_file_number  # type: ignore
+except Exception:  # pragma: no cover
+    OUTPUT_AUDIO_DIR = tempfile.gettempdir()
+
+    def ensure_subtitle_directory(subtitle_id):  # type: ignore
+        d = os.path.join(OUTPUT_AUDIO_DIR, f"subtitle_{subtitle_id}")
+        os.makedirs(d, exist_ok=True)
+        return d
+
+    def get_next_file_number(d):  # type: ignore
+        return len([f for f in os.listdir(d) if f.endswith('.wav')]) + 1
+
+logger = logging.getLogger(__name__)
+camb_bp = Blueprint('narration_camb', __name__)
+
+try:
+    from camb.client import CambAI  # type: ignore
+    from camb.types.stream_tts_output_configuration import StreamTtsOutputConfiguration  # type: ignore
+    HAS_CAMB = True
+except Exception:  # pragma: no cover
+    CambAI = None  # type: ignore
+    StreamTtsOutputConfiguration = None  # type: ignore
+    HAS_CAMB = False
+    logger.warning("camb-sdk not installed — Camb blueprint will return 503")
+
+DEFAULT_VOICE_ID = int(os.environ.get('CAMB_DEFAULT_VOICE_ID', '156549'))
+
+
+def _get(obj, key, default=None):
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _get_client():
+    api_key = os.environ.get('CAMB_API_KEY')
+    if not api_key:
+        raise RuntimeError('CAMB_API_KEY not set')
+    if not HAS_CAMB:
+        raise RuntimeError('camb-sdk not installed — run: uv pip install camb-sdk')
+    return CambAI(api_key=api_key)
+
+
+_SRC_LANGS: Optional[list] = None
+_TGT_LANGS: Optional[list] = None
+
+
+def _resolve_lang(list_langs, code: str) -> Optional[int]:
+    if not code:
+        return None
+    low = str(code).strip().lower()
+    base = low.split('-')[0].split('_')[0]
+
+    def sn(l):
+        return (_get(l, 'short_name') or '').lower()
+
+    for l in list_langs:
+        if sn(l) == low:
+            return _get(l, 'id')
+    for l in list_langs:
+        if sn(l).startswith(base):
+            return _get(l, 'id')
+    return None
+
+
+def _source_lang_id(client, code: str) -> int:
+    global _SRC_LANGS
+    if _SRC_LANGS is None:
+        _SRC_LANGS = client.languages.get_source_languages()
+    return _resolve_lang(_SRC_LANGS, code) or 1
+
+
+def _target_lang_id(client, code: str) -> int:
+    global _TGT_LANGS
+    if _TGT_LANGS is None:
+        _TGT_LANGS = client.languages.get_target_languages()
+    return _resolve_lang(_TGT_LANGS, code) or 139
+
+
+def _poll(status_fn, task_id: str, interval: float = 3.0, timeout: float = 900.0):
+    start = time.time()
+    while time.time() - start < timeout:
+        res = status_fn(task_id=task_id)
+        st = _get(res, 'status')
+        if st == 'SUCCESS':
+            return _get(res, 'run_id')
+        if st in ('ERROR', 'FAILURE', 'REVOKED'):
+            reason = _get(res, 'exception_reason') or _get(res, 'message') or st
+            raise RuntimeError(f'Camb task {task_id} failed: {reason}')
+        time.sleep(interval)
+    raise TimeoutError(f'Camb task {task_id} timed out after {timeout}s')
+
+
+def _save_audio(audio_bytes: bytes, subtitle_id, method: str = 'camb') -> str:
+    subtitle_dir = ensure_subtitle_directory(subtitle_id)
+    n = get_next_file_number(subtitle_dir)
+    filename = f"{method}_{n}.wav"
+    path = os.path.join(subtitle_dir, filename)
+    with open(path, 'wb') as f:
+        f.write(audio_bytes)
+    return path
+
+
+# ------------------------------ routes ------------------------------------
+
+@camb_bp.route('/camb/health', methods=['GET'])
+def health():
+    return jsonify({
+        'available': HAS_CAMB and bool(os.environ.get('CAMB_API_KEY')),
+        'sdk_installed': HAS_CAMB,
+        'api_key_set': bool(os.environ.get('CAMB_API_KEY')),
+    })
+
+
+@camb_bp.route('/camb/voices', methods=['GET'])
+def voices():
+    try:
+        api_key = os.environ.get('CAMB_API_KEY')
+        if not api_key:
+            return jsonify({'error': 'CAMB_API_KEY not set'}), 503
+        import urllib.request
+        req = urllib.request.Request(
+            'https://client.camb.ai/apis/list-voices',
+            headers={'x-api-key': api_key},
+        )
+        with urllib.request.urlopen(req, timeout=30) as r:
+            data = json.loads(r.read().decode('utf-8'))
+        lang = request.args.get('language', '').lower()
+        if lang:
+            data = [v for v in data if lang in str(v.get('language') or '').lower()]
+        return jsonify({'count': len(data), 'voices': data[:200]})
+    except Exception as e:
+        logger.exception('voices failed')
+        return jsonify({'error': str(e)}), 500
+
+
+@camb_bp.route('/camb/generate', methods=['POST'])
+def generate():
+    payload = request.get_json(silent=True) or {}
+    text = payload.get('text', '')
+    if not text or not text.strip():
+        return jsonify({'error': 'text is required'}), 400
+    language = payload.get('language', 'en-us')
+    speech_model = payload.get('speech_model', 'mars-flash')
+    voice_id = int(payload.get('voice_id') or DEFAULT_VOICE_ID)
+    subtitle_id = payload.get('subtitle_id')
+    try:
+        client = _get_client()
+        chunks = client.text_to_speech.tts(
+            text=text,
+            language=language,
+            speech_model=speech_model,
+            voice_id=voice_id,
+            output_configuration=StreamTtsOutputConfiguration(format='wav', sample_rate=22050),
+        )
+        buf = bytearray()
+        for chunk in chunks:
+            if isinstance(chunk, (bytes, bytearray)):
+                buf.extend(chunk)
+        audio = bytes(buf)
+        if subtitle_id is not None:
+            saved = _save_audio(audio, subtitle_id)
+            return jsonify({'ok': True, 'path': saved, 'bytes': len(audio)})
+        return Response(audio, mimetype='audio/wav')
+    except Exception as e:
+        logger.exception('generate failed')
+        return jsonify({'error': str(e)}), 500
+
+
+@camb_bp.route('/camb/transcribe', methods=['POST'])
+def transcribe():
+    f = request.files.get('file')
+    if not f:
+        return jsonify({'error': 'file field required'}), 400
+    language = request.form.get('language', 'en')
+    suffix = os.path.splitext(f.filename or 'segment.wav')[1] or '.wav'
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        f.save(tmp.name)
+        tmp_path = tmp.name
+    try:
+        client = _get_client()
+        lang_id = _source_lang_id(client, language)
+        with open(tmp_path, 'rb') as fh:
+            created = client.transcription.create_transcription(
+                media_file=fh, language=lang_id,
+            )
+        task_id = _get(created, 'task_id')
+        if not task_id:
+            raise RuntimeError(f'no task_id from create_transcription: {created!r}')
+        run_id = _poll(client.transcription.get_transcription_task_status, task_id)
+        result = client.transcription.get_transcription_result(run_id=run_id)
+        segs = _get(result, 'transcript') or []
+        out = [{
+            'start': float(_get(s, 'start', 0.0) or 0.0),
+            'end': float(_get(s, 'end', 0.0) or 0.0),
+            'text': _get(s, 'text', '') or '',
+            'speaker': _get(s, 'speaker', '') or '',
+        } for s in segs]
+        return jsonify({'segments': out, 'language': language})
+    except Exception as e:
+        logger.exception('transcribe failed')
+        return jsonify({'error': str(e)}), 500
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+@camb_bp.route('/camb/dub', methods=['POST'])
+def dub():
+    payload = request.get_json(silent=True) or {}
+    video_url = payload.get('video_url', '')
+    if not video_url.startswith(('http://', 'https://')):
+        return jsonify({'error': 'video_url must be a public http(s) URL'}), 400
+    source_language = payload.get('source_language', 'en')
+    target_language = payload.get('target_language', 'zh')
+    try:
+        client = _get_client()
+        src = _source_lang_id(client, source_language)
+        tgt = _target_lang_id(client, target_language)
+        created = client.dub.create_dub(
+            video_url=video_url,
+            source_language=src,
+            target_language=tgt,
+        )
+        task_id = _get(created, 'task_id')
+        if not task_id:
+            raise RuntimeError(f'no task_id from create_dub: {created!r}')
+        run_id = _poll(
+            client.dub.get_dubbing_status, task_id,
+            interval=5.0, timeout=1800.0,
+        )
+        info = client.dub.get_dubbed_run_info(run_id=run_id)
+        return jsonify({'run_id': run_id,
+                         'info': info if isinstance(info, dict) else info.model_dump()})
+    except Exception as e:
+        logger.exception('dub failed')
+        return jsonify({'error': str(e)}), 500

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,3 +7,4 @@ protobuf>=4.25.8,<7
 
 torch
 f5-tts
+camb-sdk

--- a/server/routes/narrationRoutes.js
+++ b/server/routes/narrationRoutes.js
@@ -10,6 +10,7 @@ const narrationController = require("../controllers/narrationController");
 const narrationServiceClient = require("../services/narrationServiceClient");
 const edgeTTSController = require("../controllers/edgeTTSController");
 const gttsController = require("../controllers/gttsController");
+const cambController = require("../controllers/cambController");
 
 // Ensure narration directories exist
 narrationController.ensureNarrationDirectories();
@@ -212,6 +213,13 @@ router.post("/edge-tts/generate", edgeTTSController.generateNarration);
 router.get("/gtts/languages", gttsController.getLanguages);
 router.post("/gtts/generate", gttsController.generateNarration);
 
+// Camb AI routes (handled directly by Node.js)
+router.get("/camb/status", cambController.getStatus);
+router.get("/camb/voices", cambController.getVoices);
+router.post("/camb/generate", cambController.generateNarration);
+router.post("/camb/transcribe", express.json({ limit: "50mb" }), cambController.transcribe);
+router.post("/camb/dub", express.json({ limit: "50mb" }), cambController.dub);
+
 // Proxy all other narration requests to the Python service
 router.use("/", async (req, res, next) => {
   // Skip endpoints we handle directly
@@ -239,7 +247,8 @@ router.use("/", async (req, res, next) => {
     req.url === "/batch-get-audio-durations" ||
     req.url.startsWith("/audio/") ||
     req.url.startsWith("/edge-tts/") ||
-    req.url.startsWith("/gtts/")
+    req.url.startsWith("/gtts/") ||
+    req.url.startsWith("/camb/")
   ) {
     return next();
   }

--- a/server/routes/parakeetRoutes.js
+++ b/server/routes/parakeetRoutes.js
@@ -45,4 +45,31 @@ router.post('/parakeet/transcribe', async (req, res) => {
   }
 });
 
+// --- Camb AI STT passthrough (mounted on the same FastAPI host as Parakeet) ---
+router.get('/camb/health', async (req, res) => {
+  try {
+    const resp = await axios.get(`${PARAKEET_BASE_URL}/camb/`);
+    res.json({ success: true, service: resp.data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+router.post('/camb/transcribe', async (req, res) => {
+  try {
+    const { audio_base64, filename, language = 'en' } = req.body || {};
+    if (!audio_base64) return res.status(400).json({ success: false, error: 'audio_base64 is required' });
+    const resp = await axios.post(
+      `${PARAKEET_BASE_URL}/camb/transcribe_base64`,
+      { audio_base64, filename: filename || 'segment.wav', language },
+      { timeout: 1000 * 60 * 10 },
+    );
+    res.json({ success: true, ...resp.data });
+  } catch (err) {
+    const status = err.response?.status || 500;
+    const detail = err.response?.data || { error: err.message };
+    res.status(status).json({ success: false, ...detail });
+  }
+});
+
 module.exports = router;

--- a/src/components/narration/UnifiedNarrationSection.js
+++ b/src/components/narration/UnifiedNarrationSection.js
@@ -11,6 +11,7 @@ import useGeminiNarration from './hooks/useGeminiNarration';
 import useChatterboxNarration from './hooks/useChatterboxNarration';
 import useEdgeTTSNarration from './hooks/useEdgeTTSNarration';
 import useGTTSNarration from './hooks/useGTTSNarration';
+import useCambNarration from './hooks/useCambNarration';
 import useAudioPlayback from './hooks/useAudioPlayback';
 import useNarrationStorage from './hooks/useNarrationStorage';
 import useUIEffects from './hooks/useUIEffects';
@@ -25,6 +26,7 @@ import GeminiSubtitleSourceSelection from './components/GeminiSubtitleSourceSele
 import ChatterboxControls from './components/ChatterboxControls';
 import EdgeTTSControls from './components/EdgeTTSControls';
 import GTTSControls from './components/GTTSControls';
+import CambControls from './components/CambControls';
 import GeminiVoiceSelection from './components/GeminiVoiceSelection';
 import GeminiConcurrentClientsSlider from './components/GeminiConcurrentClientsSlider';
 import AdvancedSettingsToggle from './components/AdvancedSettingsToggle';
@@ -95,6 +97,13 @@ const UnifiedNarrationSection = ({
     gttsLanguage, setGttsLanguage,
     gttsTld, setGttsTld,
     gttsSlow, setGttsSlow,
+
+    // Camb AI-specific settings
+    cambVoice, setCambVoice,
+    cambLanguage, setCambLanguage,
+    cambUseDub, setCambUseDub,
+    cambDubTargetLanguage, setCambDubTargetLanguage,
+    isCambAvailable,
 
     // Narration Settings state (for F5-TTS)
     referenceAudio, setReferenceAudio,
@@ -287,6 +296,31 @@ const UnifiedNarrationSection = ({
       : (subtitleSource === 'translated' && translatedSubtitles && translatedSubtitles.length > 0)
         ? translatedSubtitles
         : (originalSubtitles || subtitles || [])
+  });
+
+  // Use Camb AI narration hook
+  const {
+    handleCambNarration,
+    cancelCambGeneration,
+    handleCambDub,
+    retryCambNarration
+  } = useCambNarration({
+    setIsGenerating,
+    setGenerationStatus,
+    setError,
+    setGenerationResults,
+    generationResults,
+    subtitleSource,
+    originalSubtitles,
+    translatedSubtitles,
+    subtitles,
+    selectedVoice: cambVoice,
+    cambLanguage,
+    t,
+    setRetryingSubtitleId,
+    useGroupedSubtitles,
+    groupedSubtitles,
+    setUseGroupedSubtitles
   });
 
   // Use audio playback hook
@@ -558,6 +592,7 @@ const UnifiedNarrationSection = ({
         isGeminiAvailable={isGeminiAvailable}
         isEdgeTTSAvailable={true}
         isGTTSAvailable={true}
+        isCambAvailable={isCambAvailable}
       />
 
       <div className="narration-content-container" ref={contentRef}>
@@ -979,6 +1014,98 @@ const UnifiedNarrationSection = ({
            />
 
           {/* Hidden audio player for playback */}
+          <audio
+            ref={audioRef}
+            src={currentAudio?.url}
+            onEnded={handleAudioEnded}
+            style={{ display: 'none' }}
+          />
+        </div>
+      ) : narrationMethod === 'camb' ? (
+        // Camb AI UI
+        <div className="camb-content">
+          <SubtitleSourceSelection
+            subtitleSource={subtitleSource}
+            setSubtitleSource={setSubtitleSource}
+            isGenerating={isGenerating}
+            translatedSubtitles={translatedSubtitles}
+            originalSubtitles={originalSubtitles || subtitles}
+            originalLanguage={originalLanguage}
+            translatedLanguage={translatedLanguage}
+            setOriginalLanguage={setOriginalLanguage}
+            setTranslatedLanguage={setTranslatedLanguage}
+            useGroupedSubtitles={useGroupedSubtitles}
+            setUseGroupedSubtitles={setUseGroupedSubtitles}
+            isGroupingSubtitles={isGroupingSubtitles}
+            groupedSubtitles={groupedSubtitles}
+            groupingIntensity={groupingIntensity}
+            setGroupingIntensity={setGroupingIntensity}
+            onGroupedSubtitlesGenerated={setGroupedSubtitles}
+            narrationMethod={narrationMethod}
+            selectedModel={null}
+            setSelectedModel={() => {}}
+            onLanguageDetected={(source, language) => {
+              if (source === 'original') setOriginalLanguage(language);
+              else if (source === 'translated') setTranslatedLanguage(language);
+            }}
+          />
+
+          <CambControls
+            selectedVoice={cambVoice}
+            setSelectedVoice={setCambVoice}
+            cambLanguage={cambLanguage}
+            setCambLanguage={setCambLanguage}
+            useDub={cambUseDub}
+            setUseDub={setCambUseDub}
+            dubTargetLanguage={cambDubTargetLanguage}
+            setDubTargetLanguage={setCambDubTargetLanguage}
+            isGenerating={isGenerating}
+          />
+
+          <GenerateButton
+            handleGenerateNarration={async () => {
+              if (cambUseDub) {
+                // One-click Camb Dub - run the end-to-end dubbing pipeline
+                await handleCambDub({
+                  sourceUrl: localStorage.getItem('current_video_url') || undefined,
+                  sourcePath: videoPath,
+                  sourceLanguage: (originalLanguage?.languageCode) || 'en',
+                  targetLanguage: cambDubTargetLanguage,
+                });
+              } else {
+                await handleCambNarration();
+              }
+            }}
+            isGenerating={isGenerating}
+            referenceAudio={null}
+            subtitleSource={subtitleSource}
+            cancelGeneration={cancelCambGeneration}
+            downloadAllAudio={downloadAllAudio}
+            downloadAlignedAudio={downloadAlignedAudio}
+            generationResults={generationResults}
+            isServiceAvailable={isCambAvailable}
+            serviceUnavailableMessage={t('narration.cambUnavailableMessage', 'Camb AI is unavailable. Set CAMB_API_KEY and install @camb-ai/sdk / camb-sdk.')}
+            narrationMethod="camb"
+          />
+
+          <NarrationResults
+            generationResults={generationResults}
+            onRetry={retryCambNarration}
+            retryingSubtitleId={retryingSubtitleId}
+            hasGenerationError={!!error && error.toLowerCase().includes('camb')}
+            currentAudio={currentAudio}
+            isPlaying={isPlaying}
+            playAudio={playAudio}
+            getAudioUrl={getAudioUrl}
+            subtitleSource={subtitleSource}
+            isGenerating={isGenerating}
+            plannedSubtitles={(useGroupedSubtitles && groupedSubtitles && groupedSubtitles.length > 0)
+              ? groupedSubtitles
+              : (subtitleSource === 'translated' && translatedSubtitles && translatedSubtitles.length > 0)
+                ? translatedSubtitles
+                : (originalSubtitles || subtitles || [])}
+          />
+
           <audio
             ref={audioRef}
             src={currentAudio?.url}

--- a/src/components/narration/components/CambControls.js
+++ b/src/components/narration/components/CambControls.js
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SERVER_URL } from '../../../config';
+
+/**
+ * Camb AI controls: voice + language picker, plus a one-click "Camb Dub" toggle.
+ * Renders underneath the subtitle source selection in the narration step,
+ * analogous to EdgeTTSControls / GTTSControls.
+ */
+const CambControls = ({
+  selectedVoice,
+  setSelectedVoice,
+  cambLanguage,
+  setCambLanguage,
+  useDub,
+  setUseDub,
+  dubTargetLanguage,
+  setDubTargetLanguage,
+  isGenerating,
+}) => {
+  const { t } = useTranslation();
+  const [voices, setVoices] = useState([]);
+  const [loadingVoices, setLoadingVoices] = useState(false);
+  const [voiceError, setVoiceError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadVoices() {
+      setLoadingVoices(true);
+      setVoiceError('');
+      try {
+        const r = await fetch(`${SERVER_URL}/api/narration/camb/voices`);
+        const data = await r.json();
+        if (!cancelled) {
+          if (data.voices) setVoices(data.voices);
+          else setVoiceError(data.error || 'Failed to load Camb voices');
+        }
+      } catch (e) {
+        if (!cancelled) setVoiceError(e.message);
+      } finally {
+        if (!cancelled) setLoadingVoices(false);
+      }
+    }
+    loadVoices();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="narration-row camb-controls-row">
+      <div className="row-label">
+        <label>{t('narration.cambSettings', 'Camb AI Settings')}:</label>
+      </div>
+      <div className="row-content" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div>
+          <label htmlFor="camb-voice" style={{ marginRight: 8 }}>
+            {t('narration.cambVoice', 'Voice')}:
+          </label>
+          <select
+            id="camb-voice"
+            value={selectedVoice || ''}
+            onChange={(e) => setSelectedVoice(e.target.value)}
+            disabled={isGenerating || loadingVoices}
+          >
+            <option value="">
+              {loadingVoices
+                ? t('narration.loadingVoices', 'Loading voices...')
+                : t('narration.cambSelectVoice', 'Select a voice')}
+            </option>
+            {voices.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.display_name}
+              </option>
+            ))}
+          </select>
+          {voiceError ? (
+            <span style={{ color: 'var(--error, #c33)', marginLeft: 8 }}>{voiceError}</span>
+          ) : null}
+        </div>
+
+        <div>
+          <label htmlFor="camb-language" style={{ marginRight: 8 }}>
+            {t('narration.cambLanguage', 'Language')}:
+          </label>
+          <input
+            id="camb-language"
+            type="text"
+            value={cambLanguage || 'en'}
+            onChange={(e) => setCambLanguage(e.target.value)}
+            disabled={isGenerating}
+            style={{ width: 80 }}
+          />
+        </div>
+
+        {/* One-click Camb Dub toggle */}
+        <div style={{ borderTop: '1px solid var(--border, #ddd)', paddingTop: 8 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={!!useDub}
+              onChange={(e) => setUseDub(e.target.checked)}
+              disabled={isGenerating}
+            />{' '}
+            {t('narration.cambDubToggle', 'Use Camb Dub (end-to-end video dubbing)')}
+          </label>
+          {useDub ? (
+            <div style={{ marginTop: 8 }}>
+              <label htmlFor="camb-dub-target" style={{ marginRight: 8 }}>
+                {t('narration.cambDubTarget', 'Dub into language')}:
+              </label>
+              <input
+                id="camb-dub-target"
+                type="text"
+                value={dubTargetLanguage || ''}
+                onChange={(e) => setDubTargetLanguage(e.target.value)}
+                placeholder="es, fr, ja, ..."
+                disabled={isGenerating}
+                style={{ width: 120 }}
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CambControls;

--- a/src/components/narration/components/NarrationMethodSelection.js
+++ b/src/components/narration/components/NarrationMethodSelection.js
@@ -25,7 +25,8 @@ const NarrationMethodSelection = ({
   isChatterboxAvailable = true,
   isGeminiAvailable = true,
   isEdgeTTSAvailable = true,
-  isGTTSAvailable = true
+  isGTTSAvailable = true,
+  isCambAvailable = true
 }) => {
   const { t } = useTranslation();
 
@@ -157,6 +158,29 @@ const NarrationMethodSelection = ({
                 {t('narration.gttsMethod', 'gTTS')}
                 {!isGTTSAvailable && (
                   <HelpIcon className="method-help-icon" title={t('narration.gttsUnavailable', '(Unavailable)')} />
+                )}
+              </label>
+            </div>
+            <div className="radio-pill">
+              <input
+                type="radio"
+                id="method-camb"
+                name="narration-method"
+                value="camb"
+                checked={narrationMethod === 'camb'}
+                onChange={() => handleMethodChange('camb')}
+                disabled={isGenerating || !isCambAvailable}
+              />
+              <label htmlFor="method-camb" className={`method-camb ${!isCambAvailable ? 'unavailable' : ''}`}>
+                <span className="voice-clone-badge">Voice Clone + Dub</span>
+                <span className="method-icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 3a9 9 0 0 0-9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0-9-9zm0 3c1.66 0 3 1.34 3 3v3c0 1.66-1.34 3-3 3s-3-1.34-3-3V9c0-1.66 1.34-3 3-3zm-5 7h2a3 3 0 0 0 3 3 3 3 0 0 0 3-3h2a5 5 0 0 1-4 4.9V19h-2v-2.1A5 5 0 0 1 7 12z"/>
+                  </svg>
+                </span>
+                {t('narration.cambMethod', 'Camb AI')}
+                {!isCambAvailable && (
+                  <HelpIcon className="method-help-icon" title={t('narration.cambUnavailable', '(Unavailable - set CAMB_API_KEY)')} />
                 )}
               </label>
             </div>

--- a/src/components/narration/hooks/useCambNarration.js
+++ b/src/components/narration/hooks/useCambNarration.js
@@ -1,0 +1,236 @@
+import { useCallback, useState } from 'react';
+import { SERVER_URL } from '../../../config';
+import { deriveSubtitleId } from '../../../utils/subtitle/idUtils';
+
+/**
+ * Camb AI narration hook. Mirrors useEdgeTTSNarration but:
+ *  - targets /api/narration/camb/generate
+ *  - supports an additional one-click "dub" action via /api/narration/camb/dub
+ */
+const useCambNarration = ({
+  setIsGenerating,
+  setGenerationStatus,
+  setError,
+  setGenerationResults,
+  generationResults,
+  subtitleSource,
+  originalSubtitles,
+  translatedSubtitles,
+  subtitles,
+  selectedVoice,
+  cambLanguage,
+  t,
+  setRetryingSubtitleId,
+  useGroupedSubtitles,
+  groupedSubtitles,
+  setUseGroupedSubtitles,
+}) => {
+  const [abortController, setAbortController] = useState(null);
+
+  const getSubtitlesForGeneration = useCallback(() => {
+    if (useGroupedSubtitles && groupedSubtitles && groupedSubtitles.length > 0) {
+      return groupedSubtitles;
+    }
+    if (subtitleSource === 'original' && originalSubtitles?.length > 0) return originalSubtitles;
+    if (subtitleSource === 'translated' && translatedSubtitles?.length > 0) return translatedSubtitles;
+    return subtitles || [];
+  }, [subtitleSource, originalSubtitles, translatedSubtitles, subtitles, useGroupedSubtitles, groupedSubtitles]);
+
+  const handleCambNarration = useCallback(async () => {
+    const { clearNarrationCachesAndFiles } = await import('../utils/cacheManager');
+    await clearNarrationCachesAndFiles(setGenerationResults);
+
+    const subtitlesToProcess = getSubtitlesForGeneration();
+    if (!subtitlesToProcess?.length) {
+      setError(t('narration.noSubtitlesError', 'No subtitles available for narration generation.'));
+      return;
+    }
+
+    try {
+      setIsGenerating(true);
+      setError('');
+      setGenerationResults([]);
+
+      const controller = new AbortController();
+      setAbortController(controller);
+
+      const processed = subtitlesToProcess.map((s, idx) => ({
+        ...s,
+        id: deriveSubtitleId(s, idx),
+      }));
+
+      setGenerationStatus(t('narration.cambStarting', 'Starting Camb AI generation...'));
+
+      const response = await fetch(`${SERVER_URL}/api/narration/camb/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          subtitles: processed,
+          settings: { voice_id: selectedVoice, language: cambLanguage || 'en' },
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      const results = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value);
+        for (const line of chunk.split('\n')) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.status === 'progress' || data.status === 'error') {
+              if (data.result) {
+                results.push(data.result);
+                setGenerationResults([...results]);
+              }
+              setGenerationStatus(
+                t('narration.cambGeneratingProgress', 'Generating {{current}} of {{total}} narrations with Camb AI...', {
+                  current: data.current,
+                  total: data.total,
+                }),
+              );
+            } else if (data.status === 'completed') {
+              const finalResults = data.results || results;
+              setGenerationResults(finalResults);
+              setGenerationStatus(t('narration.cambGenerationComplete', 'Camb AI narration generation completed!'));
+              if (useGroupedSubtitles && groupedSubtitles?.length) {
+                window.groupedNarrations = [...finalResults];
+                window.useGroupedSubtitles = true;
+                setUseGroupedSubtitles(true);
+              } else {
+                if (subtitleSource === 'original') window.originalNarrations = [...finalResults];
+                else window.translatedNarrations = [...finalResults];
+                window.useGroupedSubtitles = false;
+              }
+            }
+          } catch (_e) {
+            /* ignore parse errors */
+          }
+        }
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        console.error('Camb generation error:', err);
+        setError(t('narration.cambGenerationError', 'Error generating Camb AI narration: {{error}}', { error: err.message }));
+      }
+    } finally {
+      setIsGenerating(false);
+      setAbortController(null);
+    }
+  }, [
+    getSubtitlesForGeneration,
+    selectedVoice,
+    cambLanguage,
+    setIsGenerating,
+    setError,
+    setGenerationResults,
+    setGenerationStatus,
+    t,
+    useGroupedSubtitles,
+    groupedSubtitles,
+    setUseGroupedSubtitles,
+    subtitleSource,
+  ]);
+
+  const cancelCambGeneration = useCallback(() => {
+    if (abortController) {
+      abortController.abort();
+      setAbortController(null);
+    }
+    setIsGenerating(false);
+    setGenerationStatus(t('narration.cambGenerationCancelled', 'Camb AI generation cancelled'));
+  }, [abortController, setIsGenerating, setGenerationStatus, t]);
+
+  /**
+   * One-click dub: submit a source URL (or path) and target language to Camb.
+   */
+  const handleCambDub = useCallback(
+    async ({ sourceUrl, sourcePath, sourceLanguage = 'en', targetLanguage, preserveBackground = true }) => {
+      if (!targetLanguage) {
+        setError(t('narration.cambDubNoTarget', 'Select a target language to dub into.'));
+        return null;
+      }
+      try {
+        setIsGenerating(true);
+        setError('');
+        setGenerationStatus(t('narration.cambDubbing', 'Dubbing with Camb AI (this can take a few minutes)...'));
+        const resp = await fetch(`${SERVER_URL}/api/narration/camb/dub`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            source_url: sourceUrl,
+            source_path: sourcePath,
+            source_language: sourceLanguage,
+            target_language: targetLanguage,
+            preserve_background_audio: preserveBackground,
+          }),
+        });
+        const data = await resp.json();
+        if (!resp.ok || !data.success) throw new Error(data.error || 'Dubbing failed');
+        setGenerationStatus(t('narration.cambDubComplete', 'Camb AI dubbing complete.'));
+        return data.job;
+      } catch (err) {
+        console.error('Camb dub error:', err);
+        setError(t('narration.cambDubError', 'Camb dubbing error: {{error}}', { error: err.message }));
+        return null;
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [setIsGenerating, setError, setGenerationStatus, t],
+  );
+
+  const retryCambNarration = useCallback(
+    async (subtitleId) => {
+      const all = getSubtitlesForGeneration();
+      const sub = all.find((s, idx) => deriveSubtitleId(s, idx) === subtitleId);
+      if (!sub) return;
+      setRetryingSubtitleId(subtitleId);
+      try {
+        const resp = await fetch(`${SERVER_URL}/api/narration/camb/generate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            subtitles: [{ ...sub, id: subtitleId }],
+            settings: { voice_id: selectedVoice, language: cambLanguage || 'en' },
+          }),
+        });
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          for (const line of decoder.decode(value).split('\n')) {
+            if (!line.startsWith('data: ')) continue;
+            try {
+              const data = JSON.parse(line.slice(6));
+              if (data.status === 'completed' && data.results?.length) {
+                const nr = data.results[0];
+                setGenerationResults((prev) => {
+                  let found = false;
+                  const updated = prev.map((r) => {
+                    if (r.subtitle_id === subtitleId) { found = true; return nr; }
+                    return r;
+                  });
+                  return found ? updated : [...updated, nr];
+                });
+              }
+            } catch (_e) { /* noop */ }
+          }
+        }
+      } finally {
+        setRetryingSubtitleId(null);
+      }
+    },
+    [getSubtitlesForGeneration, selectedVoice, cambLanguage, setGenerationResults, setRetryingSubtitleId],
+  );
+
+  return { handleCambNarration, cancelCambGeneration, handleCambDub, retryCambNarration };
+};
+
+export default useCambNarration;

--- a/src/components/narration/hooks/useNarrationState.js
+++ b/src/components/narration/hooks/useNarrationState.js
@@ -69,6 +69,21 @@ const useNarrationState = (initialReferenceAudio) => {
     return savedPitch || '+0Hz'; // Default to normal pitch
   });
 
+  // Camb AI-specific settings
+  const [cambVoice, setCambVoice] = useState(() => {
+    try { return localStorage.getItem('camb_voice') || ''; } catch { return ''; }
+  });
+  const [cambLanguage, setCambLanguage] = useState(() => {
+    try { return localStorage.getItem('camb_language') || 'en'; } catch { return 'en'; }
+  });
+  const [cambUseDub, setCambUseDub] = useState(() => {
+    try { return localStorage.getItem('camb_use_dub') === 'true'; } catch { return false; }
+  });
+  const [cambDubTargetLanguage, setCambDubTargetLanguage] = useState(() => {
+    try { return localStorage.getItem('camb_dub_target_language') || ''; } catch { return ''; }
+  });
+  const [isCambAvailable, setIsCambAvailable] = useState(true);
+
   // gTTS-specific settings
   const [gttsLanguage, setGttsLanguage] = useState(() => {
     // Try to load from localStorage
@@ -242,6 +257,12 @@ const useNarrationState = (initialReferenceAudio) => {
     localStorage.setItem('gtts_slow', gttsSlow.toString());
   }, [gttsSlow]);
 
+  // Save Camb AI settings to localStorage when they change
+  useEffect(() => { try { localStorage.setItem('camb_voice', cambVoice || ''); } catch {} }, [cambVoice]);
+  useEffect(() => { try { localStorage.setItem('camb_language', cambLanguage || 'en'); } catch {} }, [cambLanguage]);
+  useEffect(() => { try { localStorage.setItem('camb_use_dub', String(!!cambUseDub)); } catch {} }, [cambUseDub]);
+  useEffect(() => { try { localStorage.setItem('camb_dub_target_language', cambDubTargetLanguage || ''); } catch {} }, [cambDubTargetLanguage]);
+
   // Update local state when initialReferenceAudio changes - memoized to avoid identity changes across renders
   const updateReferenceAudio = useCallback((newReferenceAudio) => {
     if (newReferenceAudio) {
@@ -292,6 +313,18 @@ const useNarrationState = (initialReferenceAudio) => {
     setGttsTld,
     gttsSlow,
     setGttsSlow,
+
+    // Camb AI-specific settings
+    cambVoice,
+    setCambVoice,
+    cambLanguage,
+    setCambLanguage,
+    cambUseDub,
+    setCambUseDub,
+    cambDubTargetLanguage,
+    setCambDubTargetLanguage,
+    isCambAvailable,
+    setIsCambAvailable,
 
     // Narration Settings state (for F5-TTS)
     referenceAudio,

--- a/src/components/settings/SettingsModal.js
+++ b/src/components/settings/SettingsModal.js
@@ -144,6 +144,13 @@ const SettingsModal = ({ onClose, onSave, apiKeysSet, setApiKeysSet }) => {
   const [showGeminiKey, setShowGeminiKey] = useState(false);
   const [showYoutubeKey, setShowYoutubeKey] = useState(false);
   const [showGeniusKey, setShowGeniusKey] = useState(false);
+  const [cambApiKey, setCambApiKey] = useState(() => {
+    try { return localStorage.getItem('camb_api_key') || ''; } catch { return ''; }
+  });
+  const [showCambKey, setShowCambKey] = useState(false);
+  useEffect(() => {
+    try { localStorage.setItem('camb_api_key', cambApiKey || ''); } catch {}
+  }, [cambApiKey]);
   const [useOAuth, setUseOAuth] = useState(false);
   const [youtubeClientId, setYoutubeClientId] = useState('');
   const [youtubeClientSecret, setYoutubeClientSecret] = useState('');
@@ -835,6 +842,10 @@ const SettingsModal = ({ onClose, onSave, apiKeysSet, setApiKeysSet }) => {
               apiKeysSet={apiKeysSet}
               setApiKeysSet={setApiKeysSet}
               enableYoutubeSearch={enableYoutubeSearch}
+              cambApiKey={cambApiKey}
+              setCambApiKey={setCambApiKey}
+              showCambKey={showCambKey}
+              setShowCambKey={setShowCambKey}
             />
           </div>
 

--- a/src/components/settings/tabs/ApiKeysTab.js
+++ b/src/components/settings/tabs/ApiKeysTab.js
@@ -63,7 +63,11 @@ const ApiKeysTab = ({
   setIsAuthenticated,
   apiKeysSet,
   setApiKeysSet,
-  enableYoutubeSearch
+  enableYoutubeSearch,
+  cambApiKey,
+  setCambApiKey,
+  showCambKey,
+  setShowCambKey,
 }) => {
   const { t } = useTranslation();
 
@@ -610,6 +614,49 @@ const ApiKeysTab = ({
               <li>{t('settings.geniusStep6', 'Paste it into the field above')}</li>
             </ol>
           </div>
+        </div>
+
+        {/* Camb AI API Key */}
+        <div className="api-key-input">
+          <label htmlFor="camb-api-key">
+            {t('settings.cambApiKey', 'Camb AI API Key')}
+            <span className={`api-key-status ${cambApiKey ? 'set' : 'not-set'}`}>
+              {cambApiKey ? t('settings.keySet', 'Set') : t('settings.keyNotSet', 'Not Set')}
+            </span>
+          </label>
+          <div className="custom-api-key-input">
+            <div className="custom-input-field">
+              <input
+                type="text"
+                id="camb-key-input"
+                className={`api-key-input-field ${!showCambKey ? 'masked-input' : ''}`}
+                value={cambApiKey || ''}
+                onChange={(e) => setCambApiKey && setCambApiKey(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') e.preventDefault(); }}
+                placeholder={t('settings.cambApiKeyPlaceholder', 'Enter your Camb AI API key')}
+                autoComplete="new-password"
+                data-lpignore="true"
+                data-form-type="other"
+                spellCheck="false"
+              />
+            </div>
+            <button
+              type="button"
+              className="toggle-visibility"
+              onClick={() => animateToggle('camb-key-input', showCambKey, setShowCambKey)}
+              aria-label={showCambKey ? t('settings.hide') : t('settings.show')}
+            >
+              {showCambKey ? t('settings.hide') : t('settings.show')}
+            </button>
+          </div>
+          <p className="api-key-help">
+            {t('settings.cambApiKeyHelp', 'Required for Camb AI TTS, STT, and one-click Dubbing. Get one at')}
+            {' '}
+            <a href="https://studio.camb.ai" target="_blank" rel="noopener noreferrer">
+              Camb AI Studio
+            </a>
+            . {t('settings.cambApiKeyEnvNote', 'Also export CAMB_API_KEY in the server environment.')}
+          </p>
         </div>
 
         {/* YouTube API Key - Right column, second row */}


### PR DESCRIPTION
## What this adds

Three Camb AI capabilities wired into existing provider selectors, plus one new one-shot dubbing action:

- TTS narration alongside F5-TTS, Chatterbox, Edge TTS, and Google TTS
- Transcription alongside Gemini and NVIDIA Parakeet
- One-click end-to-end dubbing from the narration panel

All optional and off by default. Users pick Camb from the existing narration method radio and paste their API key in Settings.

Files added or updated (Node side):
- `server/controllers/cambController.js` (new) — controller for status, voices, narration, transcribe, and dub endpoints
- `server/routes/narrationRoutes.js` — registers `/camb/*` routes
- `server/routes/parakeetRoutes.js` — `/camb/health` and `/camb/transcribe` proxies to the FastAPI wrapper
- `src/components/narration/*` — `CambControls`, `useCambNarration`, and method selection updates
- `src/components/settings/tabs/ApiKeysTab.js` + `SettingsModal.js` — Camb API key field (persisted to `localStorage`)
- `package.json` — adds `@camb-ai/sdk`

Files added or updated (Python side):
- `server/narration_service/narration_camb.py` (new) — Flask blueprint with Camb TTS, transcription, and dubbing routes
- `server/narration_service/narration_blueprint.py` — registers the blueprint
- `parakeet_wrapper/camb_stt.py` (new) — FastAPI router mirroring the Parakeet transcribe shape
- `parakeet_wrapper/app.py` — mounts the new router
- `server/requirements.txt` + `parakeet_wrapper/requirements.txt` — add `camb-sdk`

## Why Camb AI

Camb AI is the localization engine of choice for brands such as the Premier League, the NBA, NASCAR, and the Australian Open. We power dubbing and voice cloning across 140+ languages for their live and on-demand content. We think oneclick-subtitles-generator users would benefit from the same quality, so we would love to see Camb offered as an option in your project.

## How it works

- Authentication via `CAMB_API_KEY` (env var for the servers, `localStorage.camb_api_key` for the React UI).
- Node side uses the official `@camb-ai/sdk`; Python side uses `camb-sdk`.
- Streaming TTS: POST `tts-stream` with `voice_id` and `output_configuration: { format: "wav", sample_rate: 22050 }` returns real WAV bytes.
- Transcription and dubbing follow the standard task flow: create, poll `get*TaskStatus`, fetch `get*Result`.

## Verification

From a clone with `CAMB_API_KEY` exported:
- Express: `GET /api/narration/camb/status` returns `{ available: true, sdk_installed: true, api_key_set: true }`.
- `POST /api/narration/camb/generate` with `{ text: "hello", language: "en-us" }` returns ~80 KB of valid WAV (22.05 kHz mono PCM).
- `GET /api/narration/camb/voices` returns 2008 voices; filtering by language works.
- React UI at `localhost:3030`: Settings → API Keys accepts a Camb key; Narration panel shows the Camb pill; generating narration plays back the returned WAV; the Camb Dub toggle surfaces a clear error when the source isn't a public URL.

## Notes

- Camb's dubbing endpoint accepts a public video URL only; a future PR could auto-upload local uploads to a presigned URL for a smoother UX.
- Default voice id is a placeholder; the voice picker fetches `list-voices` so users can swap it.

Happy to iterate on naming, UX, or scope based on your preferences. Thank you for considering this.
